### PR TITLE
[FIX] Remove squish-pty target from utils makefile

### DIFF
--- a/src/utils/Makefile
+++ b/src/utils/Makefile
@@ -1,4 +1,4 @@
-all: setitimer-helper squish-unix squish-pty
+all: setitimer-helper squish-unix #squish-pty
 
 CC = gcc
 CFLAGS = -Wall -W


### PR DESCRIPTION
O arquivo Utils/squish-pty.c foi removido do projeto base por algum motivo, e o Makefile não tinha sido atualizado de acordo.